### PR TITLE
Simplify public API

### DIFF
--- a/kuka_external_control_sdk/CHANGELOG.rst
+++ b/kuka_external_control_sdk/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package kuka_external_control_sdk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Change motion state variables from pointer to reference
+* Rework control signal Add methods to accept stl iterators
+
 1.2.1 (2024.04.02)
 ------------------
 * Add message builder tests

--- a/kuka_external_control_sdk/common/include/kuka/external-control-sdk/common/status.h
+++ b/kuka_external_control_sdk/common/include/kuka/external-control-sdk/common/status.h
@@ -18,7 +18,7 @@
 #include "kuka/external-control-sdk/utils/os-core-udp-communication/socket.h"
 
 namespace kuka::external::control {
-enum class ReturnCode { UNSPECIFIED, OK, WARN, ERROR, TIMEOUT };
+enum class ReturnCode { UNSPECIFIED, OK, WARN, ERROR, TIMEOUT, UNSUPPORTED };
 
 struct Status {
   Status() = default;

--- a/kuka_external_control_sdk/doc/SDK_howto.md
+++ b/kuka_external_control_sdk/doc/SDK_howto.md
@@ -101,7 +101,7 @@ The methods of the IRobot class providing the general interface:
 - _CreateMonitoringSubscription(monitoring callback)_: Creates a subscriber to the robot's motion states on the client side.
 - _CancelMonitoringSubscription()_ : Terminates the motion state subscriber on the client side.
 - _HasMonitoringSubscription()_ : Checks if the client is currently subscribed to the monitoring messages of the robot.
-- _StopControlling()_ : Stops the external control session on the controller.
+- _StopControlling()_ : Stops the external control session on the controller. (The stop signal has to be sent as response to a motion state, the function also waits for a new request, if none is currently active.)
 - _StopMonitoring()_ : Stops the motion state publisher on the controller.
 - _SendControlSignal()_ : Sends out the control signal to the controller.
 - _ReceiveMotionState(timeout)_ : Attempts to receive the current motion state of the robot within the provided timeout.
@@ -239,7 +239,7 @@ The next step is to call StartControlling and create a control loop. It's recomm
 
     // ... calculate next control signal based on the actual state
 
-    rob_if->GetControlSignal().AddJointPositionValues(/* calculated joint position values */);
+    rob_if->GetControlSignal().AddJointPositionValues(/* calculated joint position values with begin and end iterators*/);
     rob_if->SendControlSignal(); // or call rob_if->SwitchControlMode() instead to change the control mode, or StopControlling() to stop the control session.
   }
 ```

--- a/kuka_external_control_sdk/iiqka/include/kuka/external-control-sdk/iiqka/configuration.h
+++ b/kuka_external_control_sdk/iiqka/include/kuka/external-control-sdk/iiqka/configuration.h
@@ -44,15 +44,15 @@ struct Configuration {
   uint32_t connection_timeout = 5000;
 
   // Cycle time in milliseconds Currently unused.
-  const uint32_t cycle_time = 4;
+  static const uint32_t cycle_time{4};
 
   // Receive timeout for monitoring in milliseconds.
   uint32_t monitoring_timeout = 6;
 
   // Ports open on the KRC to enable external control. These values are fixed.
-  const unsigned short udp_replier_port = 44444;
-  const unsigned short ecs_grpc_port = 49335;
-  const unsigned short udp_subscriber_port = 44446;
+  static const unsigned short udp_replier_port{44444};
+  static const unsigned short ecs_grpc_port{49335};
+  static const unsigned short udp_subscriber_port{44446};
 
   // Multicast address to which packets get published in monitoring mode.
   const std::string udp_subscriber_multicast_address = "239.255.123.250";

--- a/kuka_external_control_sdk/iiqka/include/kuka/external-control-sdk/iiqka/robot.h
+++ b/kuka_external_control_sdk/iiqka/include/kuka/external-control-sdk/iiqka/robot.h
@@ -23,14 +23,14 @@
 
 #include "arena_wrapper.h"
 #include "configuration.h"
-#include "proto-api/motion-services-ecs/control_signal_external.pb.h"
-#include "proto-api/motion-services-ecs/motion_services_ecs.grpc.pb.h"
-#include "proto-api/motion-services-ecs/motion_state_external.pb.h"
 #include "kuka/external-control-sdk/common/irobot.h"
 #include "kuka/external-control-sdk/utils/os-core-udp-communication/replier.h"
 #include "kuka/external-control-sdk/utils/os-core-udp-communication/secure_replier.h"
 #include "kuka/external-control-sdk/utils/os-core-udp-communication/subscriber.h"
 #include "message_builder.h"
+#include "proto-api/motion-services-ecs/control_signal_external.pb.h"
+#include "proto-api/motion-services-ecs/motion_services_ecs.grpc.pb.h"
+#include "proto-api/motion-services-ecs/motion_state_external.pb.h"
 
 namespace kuka::external::control::iiqka {
 
@@ -39,6 +39,14 @@ class Robot : public IRobot {
  public:
   Robot(Configuration);
   virtual ~Robot() override { Reset(); }
+
+  // delete copy constructor and copy assignment operator
+  Robot(const Robot&) = delete;
+  Robot& operator=(const Robot&) = delete;
+
+  // delete move constructor and move assignment operator
+  Robot(Robot&&) = delete;
+  Robot& operator=(Robot&&) = delete;
 
   // Interface implementation
  public:
@@ -119,6 +127,8 @@ class Robot : public IRobot {
   Configuration config_;
   void SetupGRPCChannel();
   Status SetupUDPChannel();
+
+  const int kStopRecvTimeout{6};
 };
 
 }  // namespace kuka::external::control::iiqka

--- a/kuka_external_control_sdk/iiqka/test/test-assets/fake_command_handling_service.cc
+++ b/kuka_external_control_sdk/iiqka/test/test-assets/fake_command_handling_service.cc
@@ -51,14 +51,14 @@ void FakeCommandHandlingService::Setup(const std::string& service_ip) {
     motion_state_external_.mutable_motion_state()->mutable_measured_positions()->add_values(0.0);
 
   for (int i = 0; i < 6; ++i)
-    motion_state_external_.mutable_motion_state()->mutable_measured_velocities()->add_values(0.0);
-
-  for (int i = 0; i < 6; ++i) 
     motion_state_external_.mutable_motion_state()->mutable_measured_torques()->add_values(12.0);
 
   for (int i = 0; i < 6; ++i) {
-    prev_control_signal_external_.mutable_control_signal()->mutable_joint_attributes()->add_stiffness(30.0);
-    prev_control_signal_external_.mutable_control_signal()->mutable_joint_attributes()->add_damping(0.7);
+    prev_control_signal_external_.mutable_control_signal()
+        ->mutable_joint_attributes()
+        ->add_stiffness(30.0);
+    prev_control_signal_external_.mutable_control_signal()->mutable_joint_attributes()->add_damping(
+        0.7);
   }
 }
 
@@ -85,11 +85,12 @@ void FakeCommandHandlingService::Setup(const std::string& service_ip) {
         requester->Setup() == os::core::udp::communication::Publisher::ErrorCode::kSuccess;
 
     while (controlling_active_) {
-        uint8_t out_buff_arr[3072] = {0};
+      uint8_t out_buff_arr[3072] = {0};
 
-        if (!motion_state_external_.SerializeToArray(out_buff_arr, motion_state_external_.ByteSizeLong())) {
-          return;
-        }
+      if (!motion_state_external_.SerializeToArray(out_buff_arr,
+                                                   motion_state_external_.ByteSizeLong())) {
+        return;
+      }
 
       requester->SendRequest(out_buff_arr, motion_state_external_.ByteSizeLong());
 
@@ -134,7 +135,8 @@ void FakeCommandHandlingService::Setup(const std::string& service_ip) {
       while (monitoring_active_) {
         uint8_t out_buff_arr[3072] = {0};
 
-        if (!motion_state_external_.SerializeToArray(out_buff_arr, motion_state_external_.ByteSizeLong())) {
+        if (!motion_state_external_.SerializeToArray(out_buff_arr,
+                                                     motion_state_external_.ByteSizeLong())) {
           return;
         }
         publisher_->Send(out_buff_arr, motion_state_external_.ByteSizeLong());

--- a/kuka_external_control_sdk/iiqka/test/test_message_builder.cc
+++ b/kuka_external_control_sdk/iiqka/test/test_message_builder.cc
@@ -14,725 +14,865 @@
 
 #include <gtest/gtest.h>
 
-#include "kuka/external-control-sdk/iiqka/message_builder.h"
-#include "kuka/external-control-sdk/iiqka/arena_wrapper.h"
+#include <array>
+#include <cmath>
+#include <map>
 
+#include "kuka/external-control-sdk/iiqka/arena_wrapper.h"
+#include "kuka/external-control-sdk/iiqka/message_builder.h"
 
 using ::testing::Test;
 
-// Note that while the control signal / motion state values are expected to be filled by radians, the tests may not follow this rule
+// Note that while the control signal / motion state values are expected to be filled by radians,
+// the tests may not follow this rule
 class TestMotionState : public ::testing::Test {
+ protected:
+  static constexpr double D_TOLERANCE = 0.01;
 };
 
 class TestControlSignal : public ::testing::Test {
+ protected:
+  static constexpr double D_TOLERANCE = 0.01;
 };
 
 TEST_F(TestMotionState, TestEmpty6Dof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 }
 
 TEST_F(TestMotionState, TestEmpty0Dof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(0);
+  kuka::external::control::iiqka::MotionState initial_motion_state(0);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredPositions().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredTorques().size(), 0);
 }
 
 TEST_F(TestMotionState, TestAssignEmpty6Dof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal empty_ms;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal empty_ms;
 
-    initial_motion_state = std::move(empty_ms);
+  initial_motion_state = std::move(empty_ms);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 }
 
 TEST_F(TestMotionState, TestAddPositionsEqualDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_positions;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_positions;
 
-    for (int i = 0; i < 6; ++i) {
-        ms_with_positions.mutable_motion_state()->mutable_measured_positions()->add_values(12.0 + (double)i);
-    }
+  for (int i = 0; i < 6; ++i) {
+    ms_with_positions.mutable_motion_state()->mutable_measured_positions()->add_values(12.0 +
+                                                                                       (double)i);
+  }
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
 
+  initial_motion_state = std::move(ms_with_positions);
 
-    initial_motion_state = std::move(ms_with_positions);
-
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredPositions()), std::vector<double>({12.0, 13.0, 14.0, 15.0, 16.0, 17.0}));
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredPositions(),
+            std::vector<double>({12.0, 13.0, 14.0, 15.0, 16.0, 17.0}));
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 }
 
 TEST_F(TestMotionState, TestAddPositionsProtobufMSHasSmallerDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_positions;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_positions;
 
-    for (int i = 0; i < 4; ++i) {
-        ms_with_positions.mutable_motion_state()->mutable_measured_positions()->add_values(12.0 + (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
+  for (int i = 0; i < 4; ++i) {
+    ms_with_positions.mutable_motion_state()->mutable_measured_positions()->add_values(12.0 +
+                                                                                       (double)i);
+  }
 
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
 
-    initial_motion_state = std::move(ms_with_positions);
-    
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[0], 12.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[1], 13.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[2], 14.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[3], 15.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[4], 0.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[5], 0.0, 0.02);
+  initial_motion_state = std::move(ms_with_positions);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[0], 12.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[1], 13.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[2], 14.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[3], 15.0, D_TOLERANCE);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[4]), true);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[5]), true);
+
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 }
 
 TEST_F(TestMotionState, TestAddPositionsProtobufMSHasGreaterDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_positions;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_positions;
 
-    for (int i = 0; i < 15; ++i) {
-        ms_with_positions.mutable_motion_state()->mutable_measured_positions()->add_values(12.0 + (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
+  for (int i = 0; i < 15; ++i) {
+    ms_with_positions.mutable_motion_state()->mutable_measured_positions()->add_values(12.0 +
+                                                                                       (double)i);
+  }
 
-    initial_motion_state = std::move(ms_with_positions);
-    
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[0], 12.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[1], 13.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[2], 14.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[3], 15.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[4], 16.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredPositions()))[5], 17.0, 0.02);
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions()->size(), 6);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
-}
+  initial_motion_state = std::move(ms_with_positions);
 
-TEST_F(TestMotionState, TestAddVelocitiesEqualDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_velocities;
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[0], 12.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[1], 13.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[2], 14.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[3], 15.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[4], 16.0, D_TOLERANCE);
+  EXPECT_NEAR((initial_motion_state.GetMeasuredPositions())[5], 17.0, D_TOLERANCE);
+  EXPECT_EQ(initial_motion_state.GetMeasuredPositions().size(), 6);
 
-    for (int i = 0; i < 6; ++i) {
-        ms_with_velocities.mutable_motion_state()->mutable_measured_velocities()->add_values(12.0 + (double)i);
-    }
-
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-
-
-    initial_motion_state = std::move(ms_with_velocities);
-
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredVelocities()), std::vector<double>({12.0, 13.0, 14.0, 15.0, 16.0, 17.0}));
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
-}
-
-TEST_F(TestMotionState, TestAddVelocitiesProtobufMSHasSmallerDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_velocities;
-
-    for (int i = 0; i < 4; ++i) {
-        ms_with_velocities.mutable_motion_state()->mutable_measured_velocities()->add_values(12.0 + (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-
-    initial_motion_state = std::move(ms_with_velocities);
-    
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[0], 12.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[1], 13.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[2], 14.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[3], 15.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[4], 0.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[5], 0.0, 0.02);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities()->size(), 6);
-
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
-}
-
-TEST_F(TestMotionState, TestAddVelocitiesProtobufMSHasGreaterDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_velocities;
-
-    for (int i = 0; i < 15; ++i) {
-        ms_with_velocities.mutable_motion_state()->mutable_measured_velocities()->add_values(12.0 + (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-
-    initial_motion_state = std::move(ms_with_velocities);
-    
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[0], 12.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[1], 13.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[2], 14.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[3], 15.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[4], 16.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredVelocities()))[5], 17.0, 0.02);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities()->size(), 6);
-
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 }
 
 TEST_F(TestMotionState, TestAddTorquesEqualDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_torques;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_torques;
 
-    for (int i = 0; i < 6; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 + (double)i);
-    }
+  for (int i = 0; i < 6; ++i) {
+    ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 +
+                                                                                   (double)i);
+  }
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 
+  initial_motion_state = std::move(ms_with_torques);
 
-    initial_motion_state = std::move(ms_with_torques);
-
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredTorques()), std::vector<double>({12.0, 13.0, 14.0, 15.0, 16.0, 17.0}));
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredTorques(),
+            std::vector<double>({12.0, 13.0, 14.0, 15.0, 16.0, 17.0}));
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
 }
 
 TEST_F(TestMotionState, TestAddTorquesProtobufMSHasSmallerDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_torques;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_torques;
 
-    for (int i = 0; i < 4; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 + (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  for (int i = 0; i < 4; ++i) {
+    ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 +
+                                                                                   (double)i);
+  }
 
-    initial_motion_state = std::move(ms_with_torques);
-    
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[0], 12.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[1], 13.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[2], 14.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[3], 15.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[4], 0.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[5], 0.0, 0.02);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques()->size(), 6);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
+  initial_motion_state = std::move(ms_with_torques);
+
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
 }
 
 TEST_F(TestMotionState, TestAddTorquesProtobufMSHasGreaterDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_torques;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_torques;
 
-    for (int i = 0; i < 15; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 + (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  for (int i = 0; i < 15; ++i) {
+    ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 +
+                                                                                   (double)i);
+  }
 
-    initial_motion_state = std::move(ms_with_torques);
-    
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[0], 12.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[1], 13.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[2], 14.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[3], 15.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[4], 16.0, 0.02);
-    EXPECT_NEAR((*(initial_motion_state.GetMeasuredTorques()))[5], 17.0, 0.02);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques()->size(), 6);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
+  initial_motion_state = std::move(ms_with_torques);
+
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
 }
-
 
 // Not possible to fill cartesian positions for iiQKA
 TEST_F(TestMotionState, TestAddCartesianPositionsEqualDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
 }
 
 TEST_F(TestMotionState, TestAddEverythingEqualDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_torques;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_torques;
 
-    for (int i = 0; i < 6; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_positions()->add_values(0 + (double)i);
-        ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 + (double)i);
-        ms_with_torques.mutable_motion_state()->mutable_measured_velocities()->add_values(12.0 - (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  for (int i = 0; i < 6; ++i) {
+    ms_with_torques.mutable_motion_state()->mutable_measured_positions()->add_values(0 + (double)i);
+    ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 +
+                                                                                   (double)i);
+  }
 
-    initial_motion_state = std::move(ms_with_torques);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredPositions()), std::vector<double>({0.0, 1.0, 2.0, 3.0, 4.0, 5.0}));
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredTorques()), std::vector<double>({12.0, 13.0, 14.0, 15.0, 16.0, 17.0}));
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredVelocities()), std::vector<double>({12.0, 11.0, 10.0, 9.0, 8.0, 7.0}));
+  initial_motion_state = std::move(ms_with_torques);
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredPositions(),
+            std::vector<double>({0.0, 1.0, 2.0, 3.0, 4.0, 5.0}));
+
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
 }
 
 TEST_F(TestMotionState, TestAddEverythingNotEqualDof) {
-    kuka::external::control::iiqka::MotionState initial_motion_state(6);
-    kuka::ecs::v1::MotionStateExternal ms_with_torques;
+  kuka::external::control::iiqka::MotionState initial_motion_state(6);
+  kuka::ecs::v1::MotionStateExternal ms_with_torques;
 
-    for (int i = 0; i < 6; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_positions()->add_values(0 + (double)i);
-    }
+  for (int i = 0; i < 6; ++i) {
+    ms_with_torques.mutable_motion_state()->mutable_measured_positions()->add_values(0 + (double)i);
+  }
 
-    for (int i = 0; i < 4; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 + (double)i);
-    }
+  for (int i = 0; i < 4; ++i) {
+    ms_with_torques.mutable_motion_state()->mutable_measured_torques()->add_values(12.0 +
+                                                                                   (double)i);
+  }
 
-    for (int i = 0; i < 15; ++i) {
-        ms_with_torques.mutable_motion_state()->mutable_measured_velocities()->add_values(12.0 - (double)i);
-    }
-    
-    EXPECT_EQ(initial_motion_state.GetMeasuredVelocities(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredPositions(), nullptr);
-    EXPECT_EQ(initial_motion_state.GetMeasuredTorques(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredVelocities().size(), 0);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredPositions()[0]), true);
+  EXPECT_EQ(std::isnan(initial_motion_state.GetMeasuredTorques()[0]), true);
 
-    initial_motion_state = std::move(ms_with_torques);
+  initial_motion_state = std::move(ms_with_torques);
 
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredPositions()), std::vector<double>({0.0, 1.0, 2.0, 3.0, 4.0, 5.0}));
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredTorques()), std::vector<double>({12.0, 13.0, 14.0, 15.0, 0.0, 0.0}));
-    EXPECT_EQ(*(initial_motion_state.GetMeasuredVelocities()), std::vector<double>({12.0, 11.0, 10.0, 9.0, 8.0, 7.0}));
+  EXPECT_EQ(initial_motion_state.GetMeasuredPositions(),
+            std::vector<double>({0.0, 1.0, 2.0, 3.0, 4.0, 5.0}));
 
-    EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions(), nullptr);
+  EXPECT_EQ(initial_motion_state.GetMeasuredCartesianPositions().size(), 0);
 }
 
-
 TEST_F(TestControlSignal, TestEmpty6Dof) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestEmpty0Dof) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 0);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 0);
 
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestAssignEmpty6Dof) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestAddPositions) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
-    initial_control_signal.AddJointPositionValues(positions);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
 
-    std::vector<double> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0};
-    initial_control_signal.AddJointPositionValues(other_positions);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_command());
-    EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    for (int i = 0; i < 6; ++i) {
-        EXPECT_NEAR(result.control_signal().joint_command().values(i), 12 + (double)i, 0.02);
-    }
+  std::vector<double> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(result.control_signal().joint_command().values(i), 12 + (double)i, D_TOLERANCE);
+  }
+}
+
+TEST_F(TestControlSignal, TestAddPositionsArray) {
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+
+  std::array<double, 6> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
+
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::array<double, 6> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(result.control_signal().joint_command().values(i), 12 + (double)i, D_TOLERANCE);
+  }
+}
+
+TEST_F(TestControlSignal, TestAddPositionsMap) {
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+
+  std::map<int, double> positions = {{0, 12.0}, {1, 13.0}, {2, 14.0},
+                                     {3, 15.0}, {4, 16.0}, {5, 17.0}};
+
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
+
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::map<std::string, double> other_positions = {{"0", 2.0}, {"1", 3.0}, {"2", 4.0},
+                                                   {"3", 5.0}, {"4", 6.0}, {"5", 7.0}};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(result.control_signal().joint_command().values(i), 12 + (double)i, D_TOLERANCE);
+  }
 }
 
 TEST_F(TestControlSignal, TestAddPositionsUsingSmallerVector) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> positions = {12.0, 13.0, 14.0};
-    initial_control_signal.AddJointPositionValues(positions);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> positions = {12.0, 13.0, 14.0};
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
 
-    std::vector<double> other_positions = {2.0, 3.0, 4.0};
-    initial_control_signal.AddJointPositionValues(other_positions);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_command());
-    EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    EXPECT_NEAR(result.control_signal().joint_command().values(0), 12.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(1), 13.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(2), 14.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(3), 0.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(4), 0.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(5), 0.0, 0.02);
+  std::vector<double> other_positions = {2.0, 3.0, 4.0};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  EXPECT_NEAR(result.control_signal().joint_command().values(0), 12.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(1), 13.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(2), 14.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(3), 0.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(4), 0.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(5), 0.0, D_TOLERANCE);
+}
+
+TEST_F(TestControlSignal, TestAddPositionsUsingSmallerMap) {
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+
+  std::map<int, double> positions = {{0, 12.0}, {1, 13.0}, {2, 14.0}};
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
+
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::map<std::string, double> other_positions = {{"0", 2.0}, {"1", 3.0}, {"2", 4.0}};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  EXPECT_NEAR(result.control_signal().joint_command().values(0), 12.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(1), 13.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(2), 14.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(3), 0.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(4), 0.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(5), 0.0, D_TOLERANCE);
 }
 
 TEST_F(TestControlSignal, TestAddPositionsUsingLargerVector) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
-    initial_control_signal.AddJointPositionValues(positions);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
 
-    std::vector<double> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
-    initial_control_signal.AddJointPositionValues(other_positions);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_command());
-    EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    EXPECT_NEAR(result.control_signal().joint_command().values(0), 12.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(1), 13.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(2), 14.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(3), 15.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(4), 16.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_command().values(5), 17.0, 0.02);
+  std::vector<double> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  EXPECT_NEAR(result.control_signal().joint_command().values(0), 12.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(1), 13.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(2), 14.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(3), 15.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(4), 16.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(5), 17.0, D_TOLERANCE);
+}
+
+TEST_F(TestControlSignal, TestAddPositionsUsingLargerMap) {
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+
+  std::map<int, double> positions = {{0, 12.0}, {1, 13.0}, {2, 14.0}, {3, 15.0}, {4, 16.0},
+                                     {5, 17.0}, {6, 18.0}, {7, 19.0}, {8, 20.0}};
+
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
+
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::map<std::string, double> other_positions = {{"0", 2.0}, {"1", 3.0}, {"2", 4.0}, {"3", 5.0},
+                                                   {"4", 6.0}, {"5", 7.0}, {"6", 8.0}, {"7", 9.0}};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  EXPECT_NEAR(result.control_signal().joint_command().values(0), 12.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(1), 13.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(2), 14.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(3), 15.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(4), 16.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_command().values(5), 17.0, D_TOLERANCE);
 }
 
 TEST_F(TestControlSignal, TestAddPositionsUsingEmptyVector) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> positions;
-    initial_control_signal.AddJointPositionValues(positions);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> positions;
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
 
-    std::vector<double> other_positions;
-    initial_control_signal.AddJointPositionValues(other_positions);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::vector<double> other_positions;
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestAddTorques) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> torques = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
-    initial_control_signal.AddTorqueValues(torques);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> torques = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
+  initial_control_signal.AddTorqueValues(torques.begin(), torques.end());
 
-    std::vector<double> other_torques = {2.0, 3.0, 4.0, 5.0, 6.0};
-    initial_control_signal.AddTorqueValues(other_torques);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_torque_command());
-    EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    for (int i = 0; i < 6; ++i) {
-        EXPECT_NEAR(result.control_signal().joint_torque_command().values(i), 12 + (double)i, 0.02);
-    }
+  std::vector<double> other_torques = {2.0, 3.0, 4.0, 5.0, 6.0};
+  initial_control_signal.AddTorqueValues(other_torques.begin(), other_torques.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_torque_command());
+  EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(result.control_signal().joint_torque_command().values(i), 12 + (double)i,
+                D_TOLERANCE);
+  }
+}
+
+TEST_F(TestControlSignal, TestAddTorquesMap) {
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+
+  std::map<int, double> torques = {{0, 12.0}, {1, 13.0}, {2, 14.0},
+                                   {3, 15.0}, {4, 16.0}, {5, 17.0}};
+  initial_control_signal.AddTorqueValues(torques.begin(), torques.end());
+
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::map<std::string, double> other_torques = {{"0", 2.0}, {"1", 3.0}, {"2", 4.0},
+                                                 {"3", 5.0}, {"4", 6.0}, {"5", 7.0}};
+  initial_control_signal.AddTorqueValues(other_torques.begin(), other_torques.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_torque_command());
+  EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(result.control_signal().joint_torque_command().values(i), 12 + (double)i,
+                D_TOLERANCE);
+  }
 }
 
 TEST_F(TestControlSignal, TestAddTorquesUsingSmallerVector) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> torques = {12.0, 13.0, 14.0};
-    initial_control_signal.AddTorqueValues(torques);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> torques = {12.0, 13.0, 14.0};
+  initial_control_signal.AddTorqueValues(torques.begin(), torques.end());
 
-    std::vector<double> other_torques = {2.0, 3.0, 4.0};
-    initial_control_signal.AddTorqueValues(other_torques);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_torque_command());
-    EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(0), 12.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(1), 13.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(2), 14.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(3), 0.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(4), 0.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(5), 0.0, 0.02);
+  std::vector<double> other_torques = {2.0, 3.0, 4.0};
+  initial_control_signal.AddTorqueValues(other_torques.begin(), other_torques.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_torque_command());
+  EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(0), 12.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(1), 13.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(2), 14.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(3), 0.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(4), 0.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(5), 0.0, D_TOLERANCE);
 }
 
 TEST_F(TestControlSignal, TestAddTorquesUsingLargerVector) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> torques = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
-    initial_control_signal.AddTorqueValues(torques);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> torques = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0};
+  initial_control_signal.AddTorqueValues(torques.begin(), torques.end());
 
-    std::vector<double> other_torques = {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
-    initial_control_signal.AddTorqueValues(other_torques);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_torque_command());
-    EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(0), 12.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(1), 13.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(2), 14.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(3), 15.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(4), 16.0, 0.02);
-    EXPECT_NEAR(result.control_signal().joint_torque_command().values(5), 17.0, 0.02);
+  std::vector<double> other_torques = {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
+  initial_control_signal.AddTorqueValues(other_torques.begin(), other_torques.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_torque_command());
+  EXPECT_NE(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(0), 12.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(1), 13.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(2), 14.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(3), 15.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(4), 16.0, D_TOLERANCE);
+  EXPECT_NEAR(result.control_signal().joint_torque_command().values(5), 17.0, D_TOLERANCE);
 }
 
 TEST_F(TestControlSignal, TestAddTorquesUsingEmptyVector) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> torques;
-    initial_control_signal.AddTorqueValues(torques);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> torques;
+  initial_control_signal.AddTorqueValues(torques.begin(), torques.end());
 
-    std::vector<double> other_torques;
-    initial_control_signal.AddTorqueValues(other_torques);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
+
+  std::vector<double> other_torques;
+  initial_control_signal.AddTorqueValues(other_torques.begin(), other_torques.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestAddIpoc) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(30, 0);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 30);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(30, 0);
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 30);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestAddControlMode) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 1);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_POSITION_CONTROL);
-    
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 2);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_IMPEDANCE_CONTROL);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 3);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_VELOCITY_CONTROL);
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 1);
+  EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_POSITION_CONTROL);
 
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 4);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_TORQUE_CONTROL);
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 2);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::JOINT_IMPEDANCE_CONTROL);
 
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 5);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::CARTESIAN_POSITION_CONTROL);
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 3);
+  EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_VELOCITY_CONTROL);
 
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 6);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::CARTESIAN_IMPEDANCE_CONTROL);
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 4);
+  EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::JOINT_TORQUE_CONTROL);
 
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 7);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::CARTESIAN_VELOCITY_CONTROL);
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 5);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::CARTESIAN_POSITION_CONTROL);
 
-    result = *initial_control_signal.CreateProtobufControlSignal(0, 8);
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::WRENCH_CONTROL);
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 6);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::CARTESIAN_IMPEDANCE_CONTROL);
+
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 7);
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::CARTESIAN_VELOCITY_CONTROL);
+
+  result = *initial_control_signal.CreateProtobufControlSignal(0, 8);
+  EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::WRENCH_CONTROL);
 }
 
 TEST_F(TestControlSignal, TestStop) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0, true);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_TRUE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0, true);
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_TRUE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_EQ(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
 }
 
 TEST_F(TestControlSignal, TestOverridePreviousPositions) {
-    kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
-    kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
+  kuka::external::control::iiqka::ArenaWrapper<kuka::ecs::v1::ControlSignalExternal> arena;
+  kuka::external::control::iiqka::ControlSignal initial_control_signal(&arena, 6);
 
-    std::vector<double> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
-    initial_control_signal.AddJointPositionValues(positions);
-    
-    kuka::ecs::v1::ControlSignalExternal result = *initial_control_signal.CreateProtobufControlSignal(0, 0);
+  std::vector<double> positions = {12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
+  initial_control_signal.AddJointPositionValues(positions.begin(), positions.end());
 
-    std::vector<double> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0};
-    initial_control_signal.AddJointPositionValues(other_positions);
-    
-    EXPECT_TRUE(result.has_header());
-    EXPECT_EQ(result.header().ipoc(), 0);
-    EXPECT_TRUE(result.has_control_signal());
-    EXPECT_FALSE(result.control_signal().stop_ipo());
-    EXPECT_EQ(result.control_signal().control_mode(), kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
-    EXPECT_TRUE(result.control_signal().has_joint_command());
-    EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
-    EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
-    EXPECT_FALSE(result.control_signal().has_cartesian_command());
-    EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
-    EXPECT_FALSE(result.control_signal().has_wrench_command());
+  kuka::ecs::v1::ControlSignalExternal result =
+      *initial_control_signal.CreateProtobufControlSignal(0, 0);
 
-    for (int i = 0; i < 6; ++i) {
-        EXPECT_NEAR(result.control_signal().joint_command().values(i), 12 + (double)i, 0.02);
-    }
+  std::vector<double> other_positions = {2.0, 3.0, 4.0, 5.0, 6.0};
+  initial_control_signal.AddJointPositionValues(other_positions.begin(), other_positions.end());
+
+  EXPECT_TRUE(result.has_header());
+  EXPECT_EQ(result.header().ipoc(), 0);
+  EXPECT_TRUE(result.has_control_signal());
+  EXPECT_FALSE(result.control_signal().stop_ipo());
+  EXPECT_EQ(result.control_signal().control_mode(),
+            kuka::motion::external::EXTERNAL_CONTROL_MODE_UNSPECIFIED);
+  EXPECT_TRUE(result.control_signal().has_joint_command());
+  EXPECT_NE(result.control_signal().joint_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_torque_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_velocity_command().values_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().stiffness_size(), 0);
+  EXPECT_EQ(result.control_signal().joint_attributes().damping_size(), 0);
+  EXPECT_FALSE(result.control_signal().has_cartesian_command());
+  EXPECT_FALSE(result.control_signal().has_cartesian_attributes());
+  EXPECT_FALSE(result.control_signal().has_wrench_command());
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_NEAR(result.control_signal().joint_command().values(i), 12 + (double)i, D_TOLERANCE);
+  }
 }

--- a/kuka_external_control_sdk_examples/CHANGELOG.rst
+++ b/kuka_external_control_sdk_examples/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package kuka_external_control_sdk_examples
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Add examples package 
+* Contributors: Mark Szitanics, Gergely Kovacs, Aron Svastits

--- a/kuka_external_control_sdk_examples/src/control_example.cc
+++ b/kuka_external_control_sdk_examples/src/control_example.cc
@@ -80,7 +80,7 @@ int main(int argc, char const *argv[]) {
     // Add sine to goal positions
     for (int i = 0; i < dof; ++i) {
       if (counter == 0) {
-        start_pos[i] = actual_state.GetMeasuredPositions()->at(i);
+        start_pos[i] = actual_state.GetMeasuredPositions()[i];
       }
       reply_pos[i] = start_pos[i] + sin_ipoc;
     }
@@ -91,14 +91,15 @@ int main(int argc, char const *argv[]) {
 
     sin_ipoc = -sin(counter * 0.0004);
     // Set values in control signal
-    rob_if->GetControlSignal().AddJointPositionValues(reply_pos);
+    rob_if->GetControlSignal().AddJointPositionValues(reply_pos.begin(), reply_pos.end());
     std::cout << "Set values\n";
 
     // Set constant joint impedance attributes before switching to impedance mode
     if (counter == 5000) {
       auto stiffness = std::vector<double>(6, 100);
       auto damping = std::vector<double>(6, 0.7);
-      rob_if->GetControlSignal().AddStiffnessAndDampingValues(stiffness, damping);
+      rob_if->GetControlSignal().AddStiffnessAndDampingValues(stiffness.begin(), stiffness.end(),
+                                                              damping.begin(), damping.end());
     }
 
     // Send control signal (or switch control mode in case of the 5000th message)

--- a/kuka_external_control_sdk_examples/src/monitoring_example.cc
+++ b/kuka_external_control_sdk_examples/src/monitoring_example.cc
@@ -24,11 +24,10 @@ int main(int argc, char const *argv[]) {
 
   setup_ret = rob_if->CreateMonitoringSubscription(
       [](kuka::external::control::BaseMotionState motion_state) {
-        printf(
-            "Received motion state - A1: %f A2: %f A3: %f A4: %f A5: %f A6: %f\n",
-            motion_state.GetMeasuredPositions()->at(0), motion_state.GetMeasuredPositions()->at(1),
-            motion_state.GetMeasuredPositions()->at(2), motion_state.GetMeasuredPositions()->at(3),
-            motion_state.GetMeasuredPositions()->at(4), motion_state.GetMeasuredPositions()->at(5));
+        printf("Received motion state - A1: %f A2: %f A3: %f A4: %f A5: %f A6: %f\n",
+               motion_state.GetMeasuredPositions()[0], motion_state.GetMeasuredPositions()[1],
+               motion_state.GetMeasuredPositions()[2], motion_state.GetMeasuredPositions()[3],
+               motion_state.GetMeasuredPositions()[4], motion_state.GetMeasuredPositions()[5]);
       });
   if (setup_ret.return_code == kuka::external::control::ReturnCode::ERROR) {
     std::cerr << "Subscription failed: " << setup_ret.message << std::endl;


### PR DESCRIPTION
- remove copy and move ctor and operator of Robot class
- change motion state variables from ptr to ref
- rework Add...Values method to accept all kinds of stl begin and end iterators
- add `UNSUPPORTED` enum value
- `StopControlling` receives state if necessary
- remove velocity state checks from iiqka implementation (fake + msg builder)