### PR TITLE
Avoid dangling references to callback function

### DIFF
--- a/kuka_external_control_sdk/iiqka/src/robot.cc
+++ b/kuka_external_control_sdk/iiqka/src/robot.cc
@@ -217,7 +217,7 @@ Status Robot::CreateMonitoringSubscription(
 
   stop_monitoring_ = false;
 
-  monitoring_thread_ = std::thread([&]() {
+  monitoring_thread_ = std::thread([=]() {
     MotionState internal_motion_state(config_.dof);
 
     ArenaWrapper<kuka::ecs::v1::MotionStateExternal> monitoring_arena;


### PR DESCRIPTION
Currently only a reference to the callback function is captured but for the typical use case where one would pass in a lambda this quickly goes out of scope and becomes dangeling