### PR TITLE
Added option to reset control signal

### DIFF
--- a/kuka_external_control_sdk/common/include/kuka/external-control-sdk/common/irobot.h
+++ b/kuka_external_control_sdk/common/include/kuka/external-control-sdk/common/irobot.h
@@ -78,17 +78,16 @@ public:
   virtual Status StopMonitoring() = 0;
 
   virtual Status SendControlSignal() = 0;
-  virtual Status
-  ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) = 0;
+  virtual Status ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) = 0;
 
-  virtual BaseControlSignal &GetControlSignal() = 0;
+  virtual BaseControlSignal & GetControlSignal() = 0;
   virtual Status ResetControlSignal() = 0;
-  virtual BaseMotionState &GetLastMotionState() = 0;
+  virtual BaseMotionState & GetLastMotionState() = 0;
 
   virtual Status SwitchControlMode(ControlMode control_mode) = 0;
-  virtual Status RegisterEventHandler(std::unique_ptr<EventHandler> &&event_handler) = 0;
+  virtual Status RegisterEventHandler(std::unique_ptr<EventHandler> && event_handler) = 0;
 };
 
-} // namespace kuka::external::control
+}  // namespace kuka::external::control
 
 #endif  // KUKA__EXTERNAL_CONTROL_SDK__COMMON__IROBOT_H_

--- a/kuka_external_control_sdk/common/include/kuka/external-control-sdk/common/irobot.h
+++ b/kuka_external_control_sdk/common/include/kuka/external-control-sdk/common/irobot.h
@@ -78,15 +78,17 @@ public:
   virtual Status StopMonitoring() = 0;
 
   virtual Status SendControlSignal() = 0;
-  virtual Status ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) = 0;
+  virtual Status
+  ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) = 0;
 
-  virtual BaseControlSignal & GetControlSignal() = 0;
-  virtual BaseMotionState & GetLastMotionState() = 0;
+  virtual BaseControlSignal &GetControlSignal() = 0;
+  virtual Status ResetControlSignal() = 0;
+  virtual BaseMotionState &GetLastMotionState() = 0;
 
   virtual Status SwitchControlMode(ControlMode control_mode) = 0;
-  virtual Status RegisterEventHandler(std::unique_ptr<EventHandler> && event_handler) = 0;
+  virtual Status RegisterEventHandler(std::unique_ptr<EventHandler> &&event_handler) = 0;
 };
 
-}  // namespace kuka::external::control
+} // namespace kuka::external::control
 
 #endif  // KUKA__EXTERNAL_CONTROL_SDK__COMMON__IROBOT_H_

--- a/kuka_external_control_sdk/iiqka/include/kuka/external-control-sdk/iiqka/robot.h
+++ b/kuka_external_control_sdk/iiqka/include/kuka/external-control-sdk/iiqka/robot.h
@@ -75,6 +75,7 @@ public:
   Status ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) override;
 
   BaseControlSignal & GetControlSignal() override;
+  Status ResetControlSignal() override;
   BaseMotionState & GetLastMotionState() override;
 
   Status SwitchControlMode(ControlMode control_mode) override;

--- a/kuka_external_control_sdk/iiqka/src/robot.cc
+++ b/kuka_external_control_sdk/iiqka/src/robot.cc
@@ -360,7 +360,8 @@ Status Robot::ReceiveMotionState(std::chrono::milliseconds receive_request_timeo
 
 BaseControlSignal & Robot::GetControlSignal() { return control_signal_; }
 
-Status Robot::ResetControlSignal() {
+Status Robot::ResetControlSignal()
+{
   return {ReturnCode::UNSUPPORTED, "Resetting the control signal is not supported"};
 }
 

--- a/kuka_external_control_sdk/iiqka/src/robot.cc
+++ b/kuka_external_control_sdk/iiqka/src/robot.cc
@@ -359,6 +359,11 @@ Status Robot::ReceiveMotionState(std::chrono::milliseconds receive_request_timeo
 }
 
 BaseControlSignal & Robot::GetControlSignal() { return control_signal_; }
+
+Status Robot::ResetControlSignal() {
+  return {ReturnCode::UNSUPPORTED, "Resetting the control signal is not supported"};
+}
+
 BaseMotionState & Robot::GetLastMotionState() { return last_motion_state_; }
 
 Status Robot::SwitchControlMode(ControlMode control_mode)

--- a/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/robot.h
+++ b/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/robot.h
@@ -54,6 +54,7 @@ public:
   Status ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) override;
 
   BaseControlSignal & GetControlSignal() override;
+  Status ResetControlSignal() override;
   BaseMotionState & GetLastMotionState() override;
 
   // TODO(Svastits) add to documentation that other commands could come in between the Stop and

--- a/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/rsi/robot_interface.h
+++ b/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/rsi/robot_interface.h
@@ -53,6 +53,7 @@ public:
   Status ReceiveMotionState(std::chrono::milliseconds receive_request_timeout) override;
 
   BaseControlSignal & GetControlSignal() override;
+  Status ResetControlSignal() override;
   BaseMotionState & GetLastMotionState() override;
 
   // TODO(Svastits) add to documentation that other commands could come in between the Stop and

--- a/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/rsi/robot_interface.h
+++ b/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/rsi/robot_interface.h
@@ -81,7 +81,7 @@ public:
 
   uint64_t getIpoc() const { return last_motion_state_.GetIpoc(); }
 
-protected:
+public:
   MotionState last_motion_state_;
   MotionState initial_motion_state_;
   ControlSignal control_signal_;

--- a/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/rsi/robot_interface.h
+++ b/kuka_external_control_sdk/kss/include/kuka/external-control-sdk/kss/rsi/robot_interface.h
@@ -82,7 +82,7 @@ public:
 
   uint64_t getIpoc() const { return last_motion_state_.GetIpoc(); }
 
-public:
+protected:
   MotionState last_motion_state_;
   MotionState initial_motion_state_;
   ControlSignal control_signal_;

--- a/kuka_external_control_sdk/kss/src/mxa/client.cc
+++ b/kuka_external_control_sdk/kss/src/mxa/client.cc
@@ -185,7 +185,7 @@ void Client::StartKeepAliveThread()
 
           connected = true;
         }
-        else if (tick > kInitTimeoutTicks)
+        else if (tick > kInitTimeoutTicks && connected)
         {
           // Mark MXA UDP timeout as an error except in the first ticks, since
           // that always occurs

--- a/kuka_external_control_sdk/kss/src/robot.cc
+++ b/kuka_external_control_sdk/kss/src/robot.cc
@@ -76,6 +76,8 @@ Status Robot::ReceiveMotionState(std::chrono::milliseconds receive_request_timeo
 
 BaseControlSignal & Robot::GetControlSignal() { return installed_interface_->GetControlSignal(); }
 
+Status Robot::ResetControlSignal() { return installed_interface_->ResetControlSignal(); }
+
 BaseMotionState & Robot::GetLastMotionState() { return installed_interface_->GetLastMotionState(); }
 
 Status Robot::SwitchControlMode(ControlMode control_mode)

--- a/kuka_external_control_sdk/kss/src/rsi/robot_interface.cc
+++ b/kuka_external_control_sdk/kss/src/rsi/robot_interface.cc
@@ -134,15 +134,17 @@ Status Robot::ReceiveMotionState(std::chrono::milliseconds receive_request_timeo
 
 BaseControlSignal & Robot::GetControlSignal() { return control_signal_; }
 
-Status Robot::ResetControlSignal() {
-  if (control_signal_.InitialPositionsSet()) {
+Status Robot::ResetControlSignal()
+{
+  if (control_signal_.InitialPositionsSet())
+  {
     control_signal_.Reset();
   }
 
   return {ReturnCode::OK, "Control signal has been reset"};
 }
 
-BaseMotionState &Robot::GetLastMotionState() { return last_motion_state_; }
+BaseMotionState & Robot::GetLastMotionState() { return last_motion_state_; }
 
 Status Robot::UpdateMotionState(std::string_view xml_str)
 {

--- a/kuka_external_control_sdk/kss/src/rsi/robot_interface.cc
+++ b/kuka_external_control_sdk/kss/src/rsi/robot_interface.cc
@@ -134,7 +134,15 @@ Status Robot::ReceiveMotionState(std::chrono::milliseconds receive_request_timeo
 
 BaseControlSignal & Robot::GetControlSignal() { return control_signal_; }
 
-BaseMotionState & Robot::GetLastMotionState() { return last_motion_state_; }
+Status Robot::ResetControlSignal() {
+  if (control_signal_.InitialPositionsSet()) {
+    control_signal_.Reset();
+  }
+
+  return {ReturnCode::OK, "Control signal has been reset"};
+}
+
+BaseMotionState &Robot::GetLastMotionState() { return last_motion_state_; }
 
 Status Robot::UpdateMotionState(std::string_view xml_str)
 {


### PR DESCRIPTION
Added a function to reset the control signal of the robot interface. This function has been implemented in the common IRobot class and all its subclasses, including iiQKA and KSS (RSI). It is used to address the complex recovery process in the mxAutomation driver; in other implementations, it currently returns an UNSUPPORTED status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ResetControlSignal capability to the robot control interface, providing a unified entry point for resetting control signals. Implementations vary: some no-op/return unsupported, while others perform a conditional reset when possible.

* **Bug Fixes**
  * MXA UDP timeout handling refined so timeout error callbacks occur only after a connection was previously established, avoiding false timeout reports during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kroshu/kuka-external-control-sdk/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->