### PR TITLE
Update iiqka_os2_setup.md

### DIFF
--- a/kuka_external_control_sdk/doc/iiqka_os2_setup.md
+++ b/kuka_external_control_sdk/doc/iiqka_os2_setup.md
@@ -19,11 +19,9 @@ Update the IP address in the [`rsi_ethernet.xml`](../krc_setup/iiqka_os2/Config/
 
 ### Example network configuration
 
-- Windows computer with iiQWorks.Sim: `172.32.1.150/24`
-- Robot controller KLI: `172.32.1.147/24`
-- Robot controller RSI network: `172.32.2.147/24`
-- Control PC RSI connection: `172.32.2.148/24`
-- Control PC KLI connection: `172.32.1.148/24` (needed for EKI/mxA wrappers)
+- Windows computer with iiQWorks.Sim: `172.32.1.30/24`
+- Robot controller KLI: `172.32.1.10/24`
+- Control PC: `172.32.1.20/24`
 
 ## Steps within iiQWorks.Sim
 

--- a/kuka_external_control_sdk/doc/iiqka_os2_setup.md
+++ b/kuka_external_control_sdk/doc/iiqka_os2_setup.md
@@ -19,11 +19,11 @@ Update the IP address in the [`rsi_ethernet.xml`](../krc_setup/iiqka_os2/Config/
 
 ### Example network configuration
 
-Windows computer with iiQWorks.Sim: `172.32.1.150/24`
-Robot controller KLI: `172.32.1.147/24`
-Robot controller RSI network: `172.32.2.147/24`
-Control PC RSI connection: `172.32.2.148/24`
-Control PC KLI connection: `172.32.1.148/24` (needed for EKI/mxA wrappers)
+- Windows computer with iiQWorks.Sim: `172.32.1.150/24`
+- Robot controller KLI: `172.32.1.147/24`
+- Robot controller RSI network: `172.32.2.147/24`
+- Control PC RSI connection: `172.32.2.148/24`
+- Control PC KLI connection: `172.32.1.148/24` (needed for EKI/mxA wrappers)
 
 ## Steps within iiQWorks.Sim
 
@@ -32,15 +32,15 @@ There are several KUKA-specific files located in the [`krc_setup/iiqka_os2`](../
 ### RSI setup
 
 1. Import the [`Program/RSI/`](../krc_setup/iiqka_os2/Program/RSI/) folder to the `KRC/R1/Program` folder (in the **Program** tab in iiQWorks.Sim)
-2. Import the [`rsi_joint_pos.rsix`](../krc_setup/iiqka_os2/Config/RobotSensorInterface/Context/rsi_joint_pos.rsix) file under the **Context** field in the **Home** page **Devices** tab under **Option packages > iiQka.RobotSensorInterface**
-3. Import the [`rsi_ethernet.xml`](../krc_setup/iiqka_os2/Config/RobotSensorInterface/Ethernet%20configuration/rsi_ethernet.xml) file under **Ethernet configurations** field in the **Home** page **Devices** tab under **Option packages > iiQka.RobotSensorInterface**
+2. Import the [`rsi_joint_pos.rsix`](../krc_setup/iiqka_os2/Config/RobotSensorInterface/Context/rsi_joint_pos.rsix) file under the **Context** field in the **Home** page **Devices** tab under **Option packages > iiQKA.RobotSensorInterface**
+3. Import the [`rsi_ethernet.xml`](../krc_setup/iiqka_os2/Config/RobotSensorInterface/Ethernet%20configuration/rsi_ethernet.xml) file under **Ethernet configurations** field in the **Home** page **Devices** tab under **Option packages > iiQKA.RobotSensorInterface**
 
 For a more complex control scenario, including external axes or I/O, the context and Ethernet configuration files must be modified for the specific use case.
 
 ### EKI server setup
 
 1. Perform steps of RSI setup
-2. Import the [`EkiKSSinterface.xml`](../krc_setup/iiqka_os2/Config/EthernetKRL/Ethernet%20configuration/EkiKSSinterface.xml) file under the **Context** field in the **Home** page **Devices** tab under **Option packages > iiQka.EthernetKRL**
+2. Import the [`EkiKSSinterface.xml`](../krc_setup/iiqka_os2/Config/EthernetKRL/Ethernet%20configuration/EkiKSSinterface.xml) file under the **Context** field in the **Home** page **Devices** tab under **Option packages > iiQKA.EthernetKRL**
 3. Import the [`Program/EKIServer/`](../krc_setup/iiqka_os2/Program/EKIServer/) folder to the `KRC/R1/Program` folder (in the **Program** tab in iiQWorks.Sim)
 4. Modify the `KRC/STEU/Mada/$option.dat` file. Change the `$CHCK_MOVENA` flag to `FALSE` to prevent the system from checking whether `$MOVE_ENABLE` is connected to `$IN[1025]`:
 5. To ensure the EKI server runs automatically, edit the `KRC/R1/System/sps.sub` submit interpreter file. Add a call to `SPS_Init()` in the `USER INIT` fold and a call to `SPS_LoopCall()` in the `USER PLC` fold.

--- a/kuka_external_control_sdk/doc/kss_setup.md
+++ b/kuka_external_control_sdk/doc/kss_setup.md
@@ -37,11 +37,11 @@ Set the network interface of the computer performing external control to be on t
 
 ### Example network configuration
 
-Windows computer with WorkVisual: `172.32.1.150/24`
-Robot controller KLI: `172.32.1.147/24`
-Robot controller RSI network: `172.32.2.147/24`
-Control PC RSI connection: `172.32.2.148/24`
-Control PC KLI connection: `172.32.1.148/24` (needed for EKI/mxA wrappers)
+- Windows computer with WorkVisual: `172.32.1.150/24`
+- Robot controller KLI: `172.32.1.147/24`
+- Robot controller RSI network: `172.32.2.147/24`
+- Control PC RSI connection: `172.32.2.148/24`
+- Control PC KLI connection: `172.32.1.148/24` (needed for EKI/mxA wrappers)
 
 ## Steps within WorkVisual
 
@@ -52,7 +52,7 @@ There are several KUKA-specific files located in the [`krc_setup/kss`](../krc_se
 1. Copy all files from the [`Config/User/Common/SensorInterface/`](../krc_setup/kss/Config/User/Common/SensorInterface/) directory into the `Config/User/Common/SensorInterface/` directory.
 2. Copy all files from the [`Program/RSI/`](../krc_setup/kss/KRC/R1/Program/RSI/) directories into `KRC/R1/Program/`.
 
-For a more complex control scenario including external axes or I/O-s, the context and ethernet configuration files have to be modified for the specific use case.
+For a more complex control scenario including external axes or I/Os, the context and ethernet configuration files have to be modified for the specific use case.
 
 ### EKI server setup
 
@@ -65,7 +65,7 @@ For a more complex control scenario including external axes or I/O-s, the contex
 ### mxA server setup
 
 1. Perform steps of RSI setup
-2. Install the mxA option package with mode UDP selected (this only connects the I/O-s for the UDP setup)
+2. Install the mxA option package with mode UDP selected (this only connects the I/Os for the UDP setup)
 3. Perform the manual file manipulations described by the following files:
    1. [`UDPConfig`](../krc_setup/kss/KRC/R1/TP/mxA%20file%20manipulations/UDPConfig) to fully change to UDP mode
    2. [`mxA_TechFunction.add`](../krc_setup/kss/KRC/R1/TP/mxA%20file%20manipulations/mxA_TechFunction.add) to extend the mxA TechFunction with user defined methods that enable starting the RSI program


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated iiQKA OS2 network setup examples to reflect separate simulation, robot, and control PC addresses on a single subnet.
  - Clarified RSI/EKI setup instructions, file import paths, and option-package naming.
  - Improved KSS setup formatting and corrected I/O terminology in RSI and mxA instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->